### PR TITLE
Normative: Use IsExtensible(_O_) to check extensibility

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -23,9 +23,9 @@ contributors: Shu-yu Guo
     <dl class="header">
     </dl>
     <emu-alg>
-      1. <ins>If _O_.[[Extensible]] is *false*, throw a *TypeError* exception.</ins>
       1. If the host is a web browser, then
         1. Perform ? HostEnsureCanAddPrivateElement(_O_).
+      1. <ins>If ? IsExtensible(_O_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _entry_ be PrivateElementFind(_O_, _P_).
       1. If _entry_ is not ~empty~, throw a *TypeError* exception.
       1. Append PrivateElement { [[Key]]: _P_, [[Kind]]: ~field~, [[Value]]: _value_ } to _O_.[[PrivateElements]].
@@ -44,9 +44,9 @@ contributors: Shu-yu Guo
     </dl>
     <emu-alg>
       1. Assert: _method_.[[Kind]] is either ~method~ or ~accessor~.
-      1. <ins>If _O_.[[Extensible]] is *false*, throw a *TypeError* exception.</ins>
       1. If the host is a web browser, then
         1. Perform ? HostEnsureCanAddPrivateElement(_O_).
+      1. <ins>If ? IsExtensible(_O_) is *false*, throw a *TypeError* exception.</ins>
       1. Let _entry_ be PrivateElementFind(_O_, _method_.[[Key]]).
       1. If _entry_ is not ~empty~, throw a *TypeError* exception.
       1. Append _method_ to _O_.[[PrivateElements]].


### PR DESCRIPTION
Fixes #6

_O_.[[Extensible]] is not acceptable in these operations because not all objects have an [[Extensible]] internal slot (notably, module namespace exotic objects and Proxy exotic objects both lack such a slot).

Some noteworthy consequences of this change:
* User code can run while while installing a Private Name on an object.
* It will no longer be possible to install a Private Name on a revoked proxy (~~although it *will* still be possible to install a Private Name on a proxy that is not itself revoked but whose target is a revoked proxy,~~ or [a proxy] whose target is a non-revoked proxy for which the transitive closure of [[ProxyTarget]] accesses includes a revoked proxy).